### PR TITLE
Fix resume duplication

### DIFF
--- a/src/utils/actions/resumes/actions.ts
+++ b/src/utils/actions/resumes/actions.ts
@@ -327,7 +327,10 @@ export async function copyResume(resumeId: string): Promise<Resume> {
     throw new Error('Resume not found or access denied');
   }
 
-  const { ...resumeDataToCopy } = sourceResume;
+  // Exclude fields that should be auto-generated for the new record
+  // (id and timestamps). All other properties are copied as-is so the
+  // duplicate looks the same as the source resume.
+  const { id: _id, created_at: _created, updated_at: _updated, ...resumeDataToCopy } = sourceResume;
 
 
   const newResume = {


### PR DESCRIPTION
## Summary
- fix copyResume to omit ID and timestamp fields from the new record

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next: not found)*