### PR TITLE
Use logger instead of console logs

### DIFF
--- a/src/utils/actions/cover-letter/actions.ts
+++ b/src/utils/actions/cover-letter/actions.ts
@@ -4,6 +4,7 @@ import { LanguageModelV1, streamText } from 'ai';
 import { createStreamableValue } from 'ai/rsc';
 import { initializeAIClient, type AIConfig } from '@/utils/ai-tools';
 import { getSubscriptionPlan } from '../stripe/actions';
+import { logger } from '@/utils/logger';
 
 export async function generate(input: string, config?: AIConfig) {
   try {
@@ -95,12 +96,12 @@ export async function generate(input: string, config?: AIConfig) {
         prompt: input,
         onFinish: ({ usage }) => {
          const { promptTokens, completionTokens, totalTokens } = usage;
-  
-         // your own logic, e.g. for saving the chat history or recording usage
-         console.log('----------Usage:----------');
-         console.log('Prompt tokens:', promptTokens);
-         console.log('Completion tokens:', completionTokens);
-         console.log('Total tokens:', totalTokens);
+
+         logger.debug('Cover letter generation usage', {
+           promptTokens,
+           completionTokens,
+           totalTokens,
+         });
        },
  
       });
@@ -115,7 +116,7 @@ export async function generate(input: string, config?: AIConfig) {
 
     return { output: stream.value };
   } catch (error) {
-    console.error('Error generating cover letter:', error);
+    logger.error('Error generating cover letter', error);
     throw error;
   }
 }

--- a/src/utils/actions/resumes/actions.ts
+++ b/src/utils/actions/resumes/actions.ts
@@ -10,6 +10,7 @@ import { generateObject } from "ai";
 import { initializeAIClient } from "@/utils/ai-tools";
 import { resumeScoreSchema } from "@/lib/zod-schemas";
 import { getSubscriptionPlan } from "../stripe/actions";
+import { logger } from "@/utils/logger";
 
 
 //  SUPABASE ACTIONS
@@ -265,9 +266,9 @@ export async function createTailoredResume(
   companyName: string,
   tailoredContent: z.infer<typeof simplifiedResumeSchema>
 ) {
-  console.log('[createTailoredResume] Received jobId:', jobId);
-  console.log('[createTailoredResume] baseResume ID:', baseResume?.id);
-  console.log('[createTailoredResume] Is jobId valid UUID?:', /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(jobId || ''));
+  logger.debug('[createTailoredResume] Received jobId:', jobId);
+  logger.debug('[createTailoredResume] baseResume ID:', baseResume?.id);
+  logger.debug('[createTailoredResume] Is jobId valid UUID?:', /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(jobId || ''));
 
   const supabase = await createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
@@ -401,8 +402,7 @@ export async function generateResumeScore(
   const aiClient = isPro ? initializeAIClient(config, isPro) : initializeAIClient(config);
 
 
-  console.log("RESUME IS", resume);
-  // console.log("AICLIENT IS", aiClient);
+  logger.debug('Scoring resume', resume);
 
   try {
     const { object } = await generateObject({

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,27 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVELS: LogLevel[] = ['debug', 'info', 'warn', 'error'];
+
+// Determine log level from environment. Default to 'info'.
+const envLevel = (process.env.NEXT_PUBLIC_LOG_LEVEL || process.env.LOG_LEVEL || (process.env.NODE_ENV === 'production' ? 'warn' : 'debug')) as LogLevel;
+
+function shouldLog(level: LogLevel) {
+  const current = LEVELS.indexOf(envLevel);
+  const target = LEVELS.indexOf(level);
+  return target >= current;
+}
+
+export const logger = {
+  debug: (...args: unknown[]) => {
+    if (shouldLog('debug')) console.debug(...args);
+  },
+  info: (...args: unknown[]) => {
+    if (shouldLog('info')) console.info(...args);
+  },
+  warn: (...args: unknown[]) => {
+    if (shouldLog('warn')) console.warn(...args);
+  },
+  error: (...args: unknown[]) => {
+    if (shouldLog('error')) console.error(...args);
+  },
+};


### PR DESCRIPTION
## Summary
- add simple environment-aware logger
- reduce console logging in server actions for resumes, cover letters, and Stripe subscriptions

## Testing
- `npm run lint` *(fails: next not found)*