### PR TITLE
Add Jest setup and unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ This application requires several tables in your Supabase database:
 
 The complete schema with all required fields is provided in the `schema.sql` file.
 
+## 🧪 Running Tests
+
+Run the unit tests with:
+
+```bash
+pnpm test
+```
+
 ## 🏗️ Project Status
 
 ### Production Ready Features

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.0.6",
@@ -119,12 +120,15 @@
     "@types/node": "^20.17.11",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
+    "@types/jest": "^29.5.10",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.17.0",
     "eslint-config-next": "15.1.2",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/utils/__tests__/ai-tools.test.ts
+++ b/src/utils/__tests__/ai-tools.test.ts
@@ -1,0 +1,25 @@
+import { jest } from '@jest/globals';
+
+const openAiModel = jest.fn().mockReturnValue('openai-client');
+const createOpenAIMock = jest.fn(() => openAiModel);
+
+jest.mock('@ai-sdk/openai', () => ({
+  __esModule: true,
+  createOpenAI: createOpenAIMock,
+}));
+
+jest.mock('@ai-sdk/anthropic', () => ({ __esModule: true, createAnthropic: jest.fn() }));
+jest.mock('@ai-sdk/google', () => ({ __esModule: true, createGoogleGenerativeAI: jest.fn() }));
+jest.mock('@ai-sdk/deepseek', () => ({ __esModule: true, createDeepSeek: jest.fn() }));
+jest.mock('@ai-sdk/groq', () => ({ __esModule: true, createGroq: jest.fn() }));
+
+import { initializeAIClient } from '../ai-tools';
+
+describe('initializeAIClient', () => {
+  it('uses OpenAI when no config is provided', () => {
+    const client = initializeAIClient();
+    expect(createOpenAIMock).toHaveBeenCalledWith({ apiKey: '' });
+    expect(openAiModel).toHaveBeenCalledWith('no-model');
+    expect(client).toBe('openai-client');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and ts-jest dev deps
- configure Jest for TypeScript ESM usage
- provide a simple unit test for `initializeAIClient`
- document how to run tests

## Testing
- `pnpm test` *(fails: jest not found)*